### PR TITLE
Updating medips.R script to support an option for chromosome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+# medips-tools 1.6 introduces an option for passing a chromosome
 # medips-tools

--- a/medips.R
+++ b/medips.R
@@ -1,3 +1,7 @@
+library(MEDIPS)
+library(BSgenome.Hsapiens.UCSC.hg19)
+library(BSgenome.Hsapiens.UCSC.hg38)
+library(MEDIPSData)
 library(optparse)
 
 # command line options
@@ -6,14 +10,12 @@ option_list = list(
   make_option(c("-i", "--bamfile"), type="character", default=NULL, help="input bam file", metavar="character"),
   make_option(c("-o", "--outdir"), type="character", default=NULL, help="output directory to be created", metavar="character"),
   make_option(c("-g", "--BSgenome"), type="character", default="BSgenome.Hsapiens.UCSC.hg19", help="genome", metavar="character"),
+  make_option(c("-c", "--chromosome"), type="character", default=NULL, help="chromosome", metavar="character"),
   make_option(c("-u", "--uniq"), type="numeric", default=1e-3, help="uniq", metavar="numeric"),
   make_option(c("-e", "--extend"), type="numeric", default=300, help="extend", metavar="numeric"),
   make_option(c("-s", "--shift"), type="numeric", default=0, help="shift", metavar="numeric"),
   make_option(c("-w", "--ws"), type="numeric", default=100, help="ws", metavar="numeric"),
-  make_option(c("-n", "--samplename"), type="character", default=NULL, help="ws", metavar="character"),
-  make_option(c("-f", "--cigarFlag"), action="store_true", default=FALSE, help="simpleCigarFlag"), # add a flag simple cigar flag 
-  make_option(c("-x", "--covX"), type="numeric", default=1, help="minimum reads supporting CpGs", metavar="numeric") # specify minimum coverage
-  
+  make_option(c("-n", "--samplename"), type="character", default=NULL, help="ws", metavar="character")
 )
 
 # get options
@@ -29,20 +31,14 @@ uniq <- opt$uniq
 extend <- opt$extend
 shift <- opt$shift
 ws <- opt$ws
+chromosome <- opt$chromosome
 samplename <- opt$samplename
-simpleCigarFlag <- opt$cigarFlag
-covX <- opt$covX
-
-library(MEDIPS)
-library(BSgenome.Hsapiens.UCSC.hg19)
-library(BSgenome.Hsapiens.UCSC.hg38)
-library(MEDIPSData)
 
 # set the working dir
 setwd(basedir)
 
 # set chromosomes
-chr.select=paste0("chr",c(1:22,"X","Y"))
+chr.select=ifelse(is.null(chromosome), paste0("chr",c(1:22,"X","Y")), chromosome)
 
 # set sample name if it exists
 if (exists("samplename")) {
@@ -61,20 +57,16 @@ if(!dir.exists(outdir)){
 }
 
 # run MEDIPS and extract counts
-MeDIP.set=MEDIPS.createSet(file=bamfile, BSgenome=BSgenome, extend=extend, shift=shift, uniq=uniq, window_size=ws, chr.select=chr.select, simpleCigar = simpleCigarFlag)
+MeDIP.set=MEDIPS.createSet(file=bamfile, BSgenome=BSgenome, extend=extend, shift=shift, uniq=uniq, window_size=ws, chr.select=chr.select)
 
 # coupling
 CS <- MEDIPS.couplingVector(pattern="CG", refObj=MeDIP.set)
 
 # get saturation metrics
-sr <- MEDIPS.saturation(file=bamfile, BSgenome=BSgenome, uniq=uniq, extend=extend, shift=shift, window_size=ws, chr.select=chr.select, simpleCigar = simpleCigarFlag)
+sr <- MEDIPS.saturation(file=bamfile, BSgenome=BSgenome, uniq=uniq, extend=extend, shift=shift, window_size=ws, chr.select=chr.select)
 
 # Coverage
-cr <- MEDIPS.seqCoverage(file=bamfile, pattern="CG", BSgenome=BSgenome, extend=extend, shift=shift, uniq=uniq, chr.select=chr.select, simpleCigar = simpleCigarFlag)
-# compute the % CpG sites covered at Nx coverage
-total.CpG <- length(cr$cov.res)
-CpG.with.coverage <- length(cr$cov.res[cr$cov.res >= covX]) 
-frac.CpG.coverage <- CpG.with.coverage/total.CpG
+cr <- MEDIPS.seqCoverage(file=bamfile, pattern="CG", BSgenome=BSgenome, extend=extend, shift=shift, uniq=uniq, chr.select=chr.select)
 
 # CpG enrichment
 er <- MEDIPS.CpGenrich(file=bamfile, BSgenome=BSgenome, extend=extend, shift=shift, uniq=uniq, chr.select=chr.select)
@@ -88,7 +80,7 @@ rownames(saturation_df) <- sample_name
 write.table(saturation_df, file=paste0(outdir, "/saturation_metrics.txt"), sep="\t", row.names=T, quote=F, col.names=NA)
 
 # write out coverage metrics
-coverage_df <- data.frame(numberReadsCG=cr$numberReads, numberReadsWOCG=cr$numberReadsWO, numberCpGsitesInGenome=total.CpG, numberCpGSitesWithCov=CpG.with.coverage, fractionCpGCov=frac.CpG.coverage)
+coverage_df <- data.frame(numberReadsCG=cr$numberReads, numberReadsWOCG=cr$numberReadsWO)
 rownames(coverage_df) <- sample_name
 write.table(coverage_df, file=paste0(outdir, "/coverage_counts.txt"), sep="\t", row.names=T, quote=F, col.names=NA)
 


### PR DESCRIPTION
This has already been tested with MiSeq and NovaSeq inputs, the update is meant to enable a new option (chromosome) so that we could scatter the task that consumes the most RAM and time (extractMedipsCounts)